### PR TITLE
✨feat: 글로벌 예외처리 핸들러 구현

### DIFF
--- a/src/main/java/com/zip/community/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/zip/community/common/handler/GlobalExceptionHandler.java
@@ -1,9 +1,7 @@
 package com.zip.community.common.handler;
 
-import com.zip.community.common.response.ApiResponse;
-import com.zip.community.common.response.CustomException;
-import com.zip.community.common.response.ErrorCode;
-import com.zip.community.common.response.ExceptionDto;
+import com.zip.community.common.response.*;
+import com.zip.community.common.response.errorcode.BoardErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -16,10 +14,11 @@ public class GlobalExceptionHandler {
     // CustomException 처리 핸들러
     @ExceptionHandler(CustomException.class)
     public ApiResponse<ExceptionDto> handleCustomException(CustomException ce, HttpServletRequest request) {
-        log.error("[CustomException] code: {}, httpStatus: {}, message: {}, path: {}",
+        log.error("[CustomException] code: {}, httpStatus: {}, message: {}, , exceptionMessage: {}, path: {}",
                 ce.getErrorCode().getCode(),
                 ce.getErrorCode().getHttpStatus(),
                 ce.getMessage(),
+                ce.getExceptionMessage(),
                 request.getRequestURI(),
                 ce);
         return ApiResponse.fail(ce);
@@ -28,7 +27,7 @@ public class GlobalExceptionHandler {
     // CustomException 이외의 모든 Exception 처리 핸들러
     @ExceptionHandler(Exception.class)
     public ApiResponse<ExceptionDto> handleException(Exception e, HttpServletRequest request) {
-        CustomException ce = new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        CustomException ce = new CustomException(BoardErrorCode.INTERNAL_SERVER_ERROR);
         log.error("[CustomException] code: {}, httpStatus: {}, message: {}, path: {}",
                 ce.getErrorCode().getCode(),
                 ce.getErrorCode().getHttpStatus(),

--- a/src/main/java/com/zip/community/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/zip/community/common/handler/GlobalExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.zip.community.common.handler;
+
+import com.zip.community.common.response.ApiResponse;
+import com.zip.community.common.response.CustomException;
+import com.zip.community.common.response.ErrorCode;
+import com.zip.community.common.response.ExceptionDto;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // CustomException 처리 핸들러
+    @ExceptionHandler(CustomException.class)
+    public ApiResponse<ExceptionDto> handleCustomException(CustomException ce, HttpServletRequest request) {
+        log.error("[CustomException] code: {}, httpStatus: {}, message: {}, path: {}",
+                ce.getErrorCode().getCode(),
+                ce.getErrorCode().getHttpStatus(),
+                ce.getMessage(),
+                request.getRequestURI(),
+                ce);
+        return ApiResponse.fail(ce);
+    }
+
+    // CustomException 이외의 모든 Exception 처리 핸들러
+    @ExceptionHandler(Exception.class)
+    public ApiResponse<ExceptionDto> handleException(Exception e, HttpServletRequest request) {
+        CustomException ce = new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        log.error("[CustomException] code: {}, httpStatus: {}, message: {}, path: {}",
+                ce.getErrorCode().getCode(),
+                ce.getErrorCode().getHttpStatus(),
+                ce.getMessage(),
+                request.getRequestURI(),
+                e);
+        return ApiResponse.fail(ce);
+    }
+}

--- a/src/main/java/com/zip/community/common/response/ApiResponse.java
+++ b/src/main/java/com/zip/community/common/response/ApiResponse.java
@@ -21,6 +21,6 @@ public record ApiResponse<T>(
     }
 
     public static <T> ApiResponse<T> fail(final CustomException e) {
-        return new ApiResponse<>(e.getErrorCode().getHttpStatus(), false, null, ExceptionDto.of(e.getErrorCode()));
+        return new ApiResponse<>(e.getErrorCode().getHttpStatus(), false, null, ExceptionDto.of(e.getErrorCode(), e.getExceptionMessage()));
     }
 }

--- a/src/main/java/com/zip/community/common/response/CustomException.java
+++ b/src/main/java/com/zip/community/common/response/CustomException.java
@@ -1,12 +1,18 @@
 package com.zip.community.common.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
+@AllArgsConstructor
 public class CustomException extends RuntimeException{
-    private final ErrorCode errorCode;
+
+    private ErrorCode errorCode;
+    private String exceptionMessage;
+
+    public CustomException(ErrorCode errorCode) {
+        this(errorCode, null);
+    }
 
     public String getMessage() {
         return errorCode.getMessage();

--- a/src/main/java/com/zip/community/common/response/ErrorCode.java
+++ b/src/main/java/com/zip/community/common/response/ErrorCode.java
@@ -1,47 +1,9 @@
 package com.zip.community.common.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-@Getter
-@AllArgsConstructor
-public enum ErrorCode {
-
-    // Test Error
-    TEST_ERROR(100, HttpStatus.BAD_REQUEST, "테스트 에러입니다."),
-    // 400 Bad Request
-    BAD_REQUEST(400, HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    // 403 Bad Reques
-    Forbidden(403, HttpStatus.FORBIDDEN, "접속 권한이 없습니다."),
-    // 404 Not Found
-    NOT_FOUND_END_POINT(404, HttpStatus.NOT_FOUND, "요청한 대상이 존재하지 않습니다."),
-    // 500 Internal Server Error
-    INTERNAL_SERVER_ERROR(500, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
-
-    // 아파트
-
-
-    // 게시판
-
-    DUPLICATE_ERROR(409, HttpStatus.CONFLICT, "중복된 값이 이미 존재합니다");
-
-    // 주문 관련
-
-
-    // 오더 관련
-
-
-    // 상품 관련
-
-
-    // 리뷰 관련
-
-
-    // 유저 관련
-
-
-    private final Integer code;
-    private final HttpStatus httpStatus;
-    private final String message;
+public interface ErrorCode {
+    Integer getCode();
+    HttpStatus getHttpStatus();
+    String getMessage();
 }

--- a/src/main/java/com/zip/community/common/response/ExceptionDto.java
+++ b/src/main/java/com/zip/community/common/response/ExceptionDto.java
@@ -1,9 +1,11 @@
 package com.zip.community.common.response;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.misc.NotNull;
 
 @Getter
+@RequiredArgsConstructor
 public class ExceptionDto {
     @NotNull
     private final Integer code;
@@ -11,12 +13,15 @@ public class ExceptionDto {
     @NotNull
     private final String message;
 
-    public ExceptionDto(ErrorCode errorCode) {
+    private final String exceptionMessage;
+
+    public ExceptionDto(ErrorCode errorCode, String exceptionMessage) {
         this.code = errorCode.getCode();
         this.message = errorCode.getMessage();
+        this.exceptionMessage = exceptionMessage;
     }
 
-    public static ExceptionDto of(ErrorCode errorCode) {
-        return new ExceptionDto(errorCode);
+    public static ExceptionDto of(ErrorCode errorCode, String exceptionMessage) {
+        return new ExceptionDto(errorCode, exceptionMessage);
     }
 }

--- a/src/main/java/com/zip/community/common/response/errorcode/BoardErrorCode.java
+++ b/src/main/java/com/zip/community/common/response/errorcode/BoardErrorCode.java
@@ -1,0 +1,48 @@
+package com.zip.community.common.response.errorcode;
+
+import com.zip.community.common.response.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum BoardErrorCode implements ErrorCode {
+
+    // Test Error
+    TEST_ERROR(100, HttpStatus.BAD_REQUEST, "테스트 에러입니다."),
+    // 400 Bad Request
+    BAD_REQUEST(400, HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    // 403 Bad Reques
+    Forbidden(403, HttpStatus.FORBIDDEN, "접속 권한이 없습니다."),
+    // 404 Not Found
+    NOT_FOUND_END_POINT(404, HttpStatus.NOT_FOUND, "요청한 대상이 존재하지 않습니다."),
+    // 500 Internal Server Error
+    INTERNAL_SERVER_ERROR(500, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+
+    // 아파트
+
+
+    // 게시판
+
+    DUPLICATE_ERROR(409, HttpStatus.CONFLICT, "중복된 값이 이미 존재합니다");
+
+    // 주문 관련
+
+
+    // 오더 관련
+
+
+    // 상품 관련
+
+
+    // 리뷰 관련
+
+
+    // 유저 관련
+
+
+    private final Integer code;
+    private final HttpStatus httpStatus;
+    private final String message;
+}


### PR DESCRIPTION
## 요약
- 애플리케이션 전역에서 발생하는 예외를 통합적으로 처리하기 위해 GlobalExceptionHandler 클래스를 추가
- @RestControllerAdvice, @ExceptionHandler 사용
- CustomException과 일반 Exception을 각각 처리하여, 사용자에게 일관된 API 응답(ApiResponse.fail)을 반환하도록 구현

## 관련 이슈
- #1 

## 테스트
- 요청 및 응답
```java
@PostMapping("/test")
public ApiResponse<String> test5() {
    throw new CustomException(ErrorCode.NOT_FOUND_END_POINT);
}
```
```json
{
    "success": false,
    "data": null,
    "error": {
        "code": 404,
        "message": "요청한 대상이 존재하지 않습니다."
    }
}
```
- 로그
```
2025-03-07T21:05:27.888+09:00 ERROR 28248 --- [nio-8088-exec-2] c.z.c.c.handler.GlobalExceptionHandler   : [CustomException] code: 404, httpStatus: 404 NOT_FOUND, message: 요청한 대상이 존재하지 않습니다., path: /test5

com.zip.community.common.response.CustomException: 요청한 대상이 존재하지 않습니다.
	at com.zip.community.platform.adapter.in.web.TestCotroller.test5(TestCotroller.java:37) ~[main/:na]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
	...
```

---

### 25/03/11 변경사항 commit a2c46bbe6b72eb29bea87b2e3f0f9dd16ca303a0

- CustomException에 ErrorCode 뿐만 아니라 사용자 지정 메세지(excetionMessage) 추가로 넣을 수 있도록  수정
- 협업 시 충돌이 나지 않도록 ErrorCode 인터페이스로 생성 후 도메인별 enum 구현체 정의하여 사용하도록 수정

#### 테스트
```java
@GetMapping("/api/test")
public String test() {
    throw new CustomException(BoardErrorCode.NOT_FOUND_END_POINT);
}

@GetMapping("/api/test2")
public String test2() {
    throw new CustomException(BoardErrorCode.INTERNAL_SERVER_ERROR, "삐용삐용삐용");
}
```
```json
// /api/test 결과
{
    "success": false,
    "data": null,
    "error": {
        "code": 404,
        "message": "요청한 대상이 존재하지 않습니다.",
        "exceptionMessage": null
    }
}
// /api/test2 결과
{
    "success": false,
    "data": null,
    "error": {
        "code": 500,
        "message": "서버 내부 오류입니다.",
        "exceptionMessage": "삐용삐용삐용"
    }
}
```



