### PR TITLE
✨feat: 채팅 기능 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
 
     // websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    // rabbitmq
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/zip/community/common/config/mongo/MongoConfig.java
+++ b/src/main/java/com/zip/community/common/config/mongo/MongoConfig.java
@@ -8,9 +8,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
 @Configuration
+@EnableMongoAuditing
 public class MongoConfig extends AbstractMongoClientConfiguration {
 
     @Value("${spring.data.mongodb.uri}")

--- a/src/main/java/com/zip/community/common/config/websocket/WebSocketConfig.java
+++ b/src/main/java/com/zip/community/common/config/websocket/WebSocketConfig.java
@@ -1,0 +1,27 @@
+package com.zip.community.common.config.websocket;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@Profile("test")
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/connect")
+                .setAllowedOrigins("*");
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 메세지 구독하는 엔드포인트(/queue: 1:1, /topic: 여러 사용자)
+        registry.enableSimpleBroker("/queue", "/topic");
+        // 메세지 발행하는 엔드포인트
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/src/main/java/com/zip/community/common/response/errorcode/ChatErrorCode.java
+++ b/src/main/java/com/zip/community/common/response/errorcode/ChatErrorCode.java
@@ -11,7 +11,9 @@ public enum ChatErrorCode implements ErrorCode {
 
     NOT_FOUND_CHAT_ROOM(3001, HttpStatus.NOT_FOUND, "채팅방이 존재하지 않습니다."),
     NOT_FOUND_CHAT_MESSAGE(3002, HttpStatus.NOT_FOUND, "채팅 메세지가 존재하지 않습니다."),
-    CHAT_ROOM_CREATION_FAILED(3003, HttpStatus.INTERNAL_SERVER_ERROR, "채팅방 생성에 실패했습니다.");
+    CHAT_ROOM_CREATION_FAILED(3003, HttpStatus.INTERNAL_SERVER_ERROR, "채팅방 생성에 실패했습니다."),
+    REPORT_SAME_MEMBER(3004, HttpStatus.BAD_REQUEST, "자신을 신고할 수 없습니다."),
+    ALREADY_DELETED_MESSAGE(3005, HttpStatus.BAD_REQUEST, "이미 삭제된 메세지입니다.");
 
     private final Integer code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/zip/community/common/response/errorcode/ChatErrorCode.java
+++ b/src/main/java/com/zip/community/common/response/errorcode/ChatErrorCode.java
@@ -9,12 +9,13 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ChatErrorCode implements ErrorCode {
 
-    NOT_FOUND_CHAT_ROOM(3001, HttpStatus.NOT_FOUND, "채팅방이 존재하지 않습니다."),
-    NOT_FOUND_CHAT_MESSAGE(3002, HttpStatus.NOT_FOUND, "채팅 메세지가 존재하지 않습니다."),
-    CHAT_ROOM_CREATION_FAILED(3003, HttpStatus.INTERNAL_SERVER_ERROR, "채팅방 생성에 실패했습니다."),
-    REPORT_SAME_MEMBER(3004, HttpStatus.BAD_REQUEST, "자신을 신고할 수 없습니다."),
-    ALREADY_DELETED_MESSAGE(3005, HttpStatus.BAD_REQUEST, "이미 삭제된 메세지입니다."),
-    ALREADY_REPORTED_MESSAGE(3006, HttpStatus.BAD_REQUEST, "이미 신고한 메세지입니다.");
+    NOT_FOUND_MEMBER(3001, HttpStatus.NOT_FOUND, "해당 id의 사용자가 존재하지 않습니다."),
+    NOT_FOUND_CHAT_ROOM(3002, HttpStatus.NOT_FOUND, "채팅방이 존재하지 않습니다."),
+    NOT_FOUND_CHAT_MESSAGE(3003, HttpStatus.NOT_FOUND, "채팅 메세지가 존재하지 않습니다."),
+    CHAT_ROOM_CREATION_FAILED(3004, HttpStatus.INTERNAL_SERVER_ERROR, "채팅방 생성에 실패했습니다."),
+    REPORT_SAME_MEMBER(3005, HttpStatus.BAD_REQUEST, "자신을 신고할 수 없습니다."),
+    ALREADY_DELETED_MESSAGE(3006, HttpStatus.BAD_REQUEST, "이미 삭제된 메세지입니다."),
+    ALREADY_REPORTED_MESSAGE(3007, HttpStatus.BAD_REQUEST, "이미 신고한 메세지입니다.");
 
     private final Integer code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/zip/community/common/response/errorcode/ChatErrorCode.java
+++ b/src/main/java/com/zip/community/common/response/errorcode/ChatErrorCode.java
@@ -1,0 +1,19 @@
+package com.zip.community.common.response.errorcode;
+
+import com.zip.community.common.response.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ChatErrorCode implements ErrorCode {
+
+    NOT_FOUND_CHAT_ROOM(3001, HttpStatus.NOT_FOUND, "채팅방이 존재하지 않습니다."),
+    NOT_FOUND_CHAT_MESSAGE(3002, HttpStatus.NOT_FOUND, "채팅 메세지가 존재하지 않습니다."),
+    CHAT_ROOM_CREATION_FAILED(3003, HttpStatus.INTERNAL_SERVER_ERROR, "채팅방 생성에 실패했습니다.");
+
+    private final Integer code;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/zip/community/common/response/errorcode/ChatErrorCode.java
+++ b/src/main/java/com/zip/community/common/response/errorcode/ChatErrorCode.java
@@ -13,7 +13,8 @@ public enum ChatErrorCode implements ErrorCode {
     NOT_FOUND_CHAT_MESSAGE(3002, HttpStatus.NOT_FOUND, "채팅 메세지가 존재하지 않습니다."),
     CHAT_ROOM_CREATION_FAILED(3003, HttpStatus.INTERNAL_SERVER_ERROR, "채팅방 생성에 실패했습니다."),
     REPORT_SAME_MEMBER(3004, HttpStatus.BAD_REQUEST, "자신을 신고할 수 없습니다."),
-    ALREADY_DELETED_MESSAGE(3005, HttpStatus.BAD_REQUEST, "이미 삭제된 메세지입니다.");
+    ALREADY_DELETED_MESSAGE(3005, HttpStatus.BAD_REQUEST, "이미 삭제된 메세지입니다."),
+    ALREADY_REPORTED_MESSAGE(3006, HttpStatus.BAD_REQUEST, "이미 신고한 메세지입니다.");
 
     private final Integer code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/zip/community/platform/adapter/in/web/ChatMessageController.java
+++ b/src/main/java/com/zip/community/platform/adapter/in/web/ChatMessageController.java
@@ -1,0 +1,55 @@
+package com.zip.community.platform.adapter.in.web;
+
+import com.zip.community.common.response.ApiResponse;
+import com.zip.community.platform.adapter.in.web.dto.request.chat.MessageDeleteRequest;
+import com.zip.community.platform.adapter.in.web.dto.request.chat.MessageReportRequest;
+import com.zip.community.platform.application.port.in.chat.ChatMessageUseCase;
+import com.zip.community.platform.domain.chat.ChatMessage;
+import com.zip.community.platform.domain.report.ReportedChatMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/chat")
+@RequiredArgsConstructor
+public class ChatMessageController {
+
+    private final ChatMessageUseCase chatMessageUseCase;
+
+    // 채팅방 메세지 조회
+    @GetMapping("/messages")
+    public ApiResponse<List<ChatMessage>> getMessages(@RequestParam String chatRoomId,
+                                                      @RequestParam(defaultValue = "0") Integer page) {
+        return ApiResponse.created(chatMessageUseCase.getMessages(chatRoomId, page));
+    }
+
+    // 채팅방 특정 메세지 삭제
+    @DeleteMapping("/delete")
+    public ApiResponse<ChatMessage> deleteMessage(@RequestBody MessageDeleteRequest request) {
+        return ApiResponse.created(chatMessageUseCase.deleteMessage(request.getMessageId(), request.getMemberId()));
+    }
+
+    // 채팅방 메세지 신고
+    @PostMapping("/report")
+    public ApiResponse<ReportedChatMessage> reportMessage(@RequestBody MessageReportRequest request) {
+        return ApiResponse.created(chatMessageUseCase.reportMessage(request.getMessageId(), request.getReportMemberId(), request.getReportedMemberId(), request.getReason()));
+    }
+
+    // 채팅방 메세지 차단 -> 관리자만 가능
+    @PostMapping("/block")
+    public ApiResponse<ChatMessage> blockMessage(@RequestParam String messageId) {
+        return ApiResponse.created(chatMessageUseCase.blockMessage(messageId));
+    }
+
+    // 채팅방 메세지 검색
+    @GetMapping("/search")
+    public ApiResponse<List<ChatMessage>> searchMessages(@RequestParam String chatRoomId,
+                                                         @RequestParam String keyword) {
+
+        return ApiResponse.created(chatMessageUseCase.searchMessages(chatRoomId, keyword));
+    }
+}

--- a/src/main/java/com/zip/community/platform/adapter/in/web/ChatMessageSocketController.java
+++ b/src/main/java/com/zip/community/platform/adapter/in/web/ChatMessageSocketController.java
@@ -1,0 +1,38 @@
+package com.zip.community.platform.adapter.in.web;
+
+import com.zip.community.common.response.ApiResponse;
+import com.zip.community.platform.adapter.in.web.dto.request.chat.MessageSendRequest;
+import com.zip.community.platform.application.port.in.chat.ChatMessageUseCase;
+import com.zip.community.platform.domain.chat.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class ChatMessageSocketController {
+
+    private final ChatMessageUseCase chatMessageUseCase;
+
+    @MessageMapping("/{chatRoomId}")
+    public ApiResponse<ChatMessage> sendMessage(@DestinationVariable String chatRoomId, MessageSendRequest request) {
+        log.info("받은 메세지 {}: {}", chatRoomId, request.getContent());
+
+        ChatMessage message = ChatMessage.builder()
+                .chatRoomId(chatRoomId)
+                .content(request.getContent())
+                .senderId(request.getSenderId())
+                .senderName(request.getSenderName())
+                .sentAt(LocalDateTime.now())
+                .readYn(false)
+                .deletedYn(false)
+                .build();
+
+        return ApiResponse.created(chatMessageUseCase.sendMessage(message));
+    }
+}

--- a/src/main/java/com/zip/community/platform/adapter/in/web/ChatMessageSocketController.java
+++ b/src/main/java/com/zip/community/platform/adapter/in/web/ChatMessageSocketController.java
@@ -21,17 +21,8 @@ public class ChatMessageSocketController {
 
     @MessageMapping("/{chatRoomId}")
     public ApiResponse<ChatMessage> sendMessage(@DestinationVariable String chatRoomId, MessageSendRequest request) {
+        ChatMessage message = ChatMessage.of(chatRoomId, request.getContent(), request.getSenderId(), request.getSenderName(), LocalDateTime.now(), false, false);
         log.info("받은 메세지 {}: {}", chatRoomId, request.getContent());
-
-        ChatMessage message = ChatMessage.builder()
-                .chatRoomId(chatRoomId)
-                .content(request.getContent())
-                .senderId(request.getSenderId())
-                .senderName(request.getSenderName())
-                .sentAt(LocalDateTime.now())
-                .readYn(false)
-                .deletedYn(false)
-                .build();
 
         return ApiResponse.created(chatMessageUseCase.sendMessage(message));
     }

--- a/src/main/java/com/zip/community/platform/adapter/in/web/ChatRoomController.java
+++ b/src/main/java/com/zip/community/platform/adapter/in/web/ChatRoomController.java
@@ -1,0 +1,32 @@
+package com.zip.community.platform.adapter.in.web;
+
+import com.zip.community.common.response.ApiResponse;
+import com.zip.community.platform.adapter.in.web.dto.request.chat.ChatRoomRequest;
+import com.zip.community.platform.adapter.in.web.dto.response.ChatRoomResponse;
+import com.zip.community.platform.application.port.in.chat.ChatRoomUseCase;
+import com.zip.community.platform.domain.chat.ChatRoom;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chatroom")
+public class ChatRoomController {
+
+    private final ChatRoomUseCase chatRoomUseCase;
+
+    @PostMapping("/start")
+    public ApiResponse<ChatRoomResponse> startChat(@RequestBody ChatRoomRequest request) {
+        ChatRoom chatRoom = chatRoomUseCase.startChat(request.getUserId1(), request.getUserId2());
+        return ApiResponse.created(ChatRoomResponse.from(chatRoom));
+    }
+
+    @GetMapping("/list/{userId}")
+    public ApiResponse<List<ChatRoomResponse>> getChatRooms(@PathVariable String userId) {
+        return ApiResponse.created(ChatRoomResponse.from(chatRoomUseCase.getChatRoomsForUser(userId)));
+    }
+}

--- a/src/main/java/com/zip/community/platform/adapter/in/web/ChatRoomController.java
+++ b/src/main/java/com/zip/community/platform/adapter/in/web/ChatRoomController.java
@@ -2,7 +2,7 @@ package com.zip.community.platform.adapter.in.web;
 
 import com.zip.community.common.response.ApiResponse;
 import com.zip.community.platform.adapter.in.web.dto.request.chat.ChatRoomRequest;
-import com.zip.community.platform.adapter.in.web.dto.response.ChatRoomResponse;
+import com.zip.community.platform.adapter.in.web.dto.response.chat.ChatRoomResponse;
 import com.zip.community.platform.application.port.in.chat.ChatRoomUseCase;
 import com.zip.community.platform.domain.chat.ChatRoom;
 import lombok.RequiredArgsConstructor;
@@ -19,14 +19,16 @@ public class ChatRoomController {
 
     private final ChatRoomUseCase chatRoomUseCase;
 
+    // 채팅방 생성
     @PostMapping("/start")
     public ApiResponse<ChatRoomResponse> startChat(@RequestBody ChatRoomRequest request) {
-        ChatRoom chatRoom = chatRoomUseCase.startChat(request.getUserId1(), request.getUserId2());
+        ChatRoom chatRoom = chatRoomUseCase.startChat(request.getSenderId(), request.getReceiverId(), request.getSenderName(), request.getReceiverName());
         return ApiResponse.created(ChatRoomResponse.from(chatRoom));
     }
 
-    @GetMapping("/list/{userId}")
-    public ApiResponse<List<ChatRoomResponse>> getChatRooms(@PathVariable String userId) {
-        return ApiResponse.created(ChatRoomResponse.from(chatRoomUseCase.getChatRoomsForUser(userId)));
+    // 채팅방 목록 조회
+    @GetMapping("/list/{memberId}")
+    public ApiResponse<List<ChatRoomResponse>> getChatRooms(@PathVariable Long memberId) {
+        return ApiResponse.created(ChatRoomResponse.from(chatRoomUseCase.getChatRoomsForUser(memberId)));
     }
 }

--- a/src/main/java/com/zip/community/platform/adapter/in/web/dto/request/chat/ChatRoomRequest.java
+++ b/src/main/java/com/zip/community/platform/adapter/in/web/dto/request/chat/ChatRoomRequest.java
@@ -1,0 +1,12 @@
+package com.zip.community.platform.adapter.in.web.dto.request.chat;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChatRoomRequest {
+
+    private String userId1;
+    private String userId2;
+}

--- a/src/main/java/com/zip/community/platform/adapter/in/web/dto/request/chat/MessageDeleteRequest.java
+++ b/src/main/java/com/zip/community/platform/adapter/in/web/dto/request/chat/MessageDeleteRequest.java
@@ -1,0 +1,12 @@
+package com.zip.community.platform.adapter.in.web.dto.request.chat;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MessageDeleteRequest {
+
+    private String messageId;
+    private Long memberId;
+}

--- a/src/main/java/com/zip/community/platform/adapter/in/web/dto/request/chat/MessageReportRequest.java
+++ b/src/main/java/com/zip/community/platform/adapter/in/web/dto/request/chat/MessageReportRequest.java
@@ -1,0 +1,13 @@
+package com.zip.community.platform.adapter.in.web.dto.request.chat;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MessageReportRequest {
+
+    private String messageId;
+    private Long reportMemberId;
+    private String reason;
+}

--- a/src/main/java/com/zip/community/platform/adapter/in/web/dto/request/chat/MessageReportRequest.java
+++ b/src/main/java/com/zip/community/platform/adapter/in/web/dto/request/chat/MessageReportRequest.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 public class MessageReportRequest {
 
     private String messageId;
-    private Long reportMemberId;
+    private Long reportMemberId;    // 신고한 회원 ID
+    private Long reportedMemberId;  // 신고당한 회원 ID
     private String reason;
 }

--- a/src/main/java/com/zip/community/platform/adapter/in/web/dto/request/chat/MessageSendRequest.java
+++ b/src/main/java/com/zip/community/platform/adapter/in/web/dto/request/chat/MessageSendRequest.java
@@ -5,10 +5,8 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class ChatRoomRequest {
+public class MessageSendRequest {
 
+    private String content;
     private Long senderId;
-    private Long receiverId;
-    private String senderName;
-    private String receiverName;
 }

--- a/src/main/java/com/zip/community/platform/adapter/in/web/dto/request/chat/MessageSendRequest.java
+++ b/src/main/java/com/zip/community/platform/adapter/in/web/dto/request/chat/MessageSendRequest.java
@@ -9,4 +9,5 @@ public class MessageSendRequest {
 
     private String content;
     private Long senderId;
+    private String senderName;
 }

--- a/src/main/java/com/zip/community/platform/adapter/in/web/dto/response/ChatRoomResponse.java
+++ b/src/main/java/com/zip/community/platform/adapter/in/web/dto/response/ChatRoomResponse.java
@@ -1,0 +1,42 @@
+package com.zip.community.platform.adapter.in.web.dto.response;
+
+import com.zip.community.platform.domain.chat.ChatRoom;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatRoomResponse {
+
+    private String id;
+    private String userId1;
+    private String userId2;
+    private String lastMessage;
+    private LocalDateTime lastMessageTime;
+
+    // 단일 반환
+    public static ChatRoomResponse from(ChatRoom chatRoom) {
+        return ChatRoomResponse.builder()
+                .id(chatRoom.getId())
+                .userId1(chatRoom.getParticipants().getFirst())
+                .userId2(chatRoom.getParticipants().getLast())
+                .lastMessage(chatRoom.getLastMessage().getContent())
+                .lastMessageTime(chatRoom.getLastMessage().getSentAt())
+                .build();
+    }
+
+    // List 반환
+    public static List<ChatRoomResponse> from(List<ChatRoom> chatRooms) {
+        return chatRooms.stream()
+                .map(ChatRoomResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/zip/community/platform/adapter/in/web/dto/response/chat/ChatRoomResponse.java
+++ b/src/main/java/com/zip/community/platform/adapter/in/web/dto/response/chat/ChatRoomResponse.java
@@ -1,6 +1,7 @@
-package com.zip.community.platform.adapter.in.web.dto.response;
+package com.zip.community.platform.adapter.in.web.dto.response.chat;
 
 import com.zip.community.platform.domain.chat.ChatRoom;
+import com.zip.community.platform.domain.chat.Participant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,8 +18,7 @@ import java.util.stream.Collectors;
 public class ChatRoomResponse {
 
     private String id;
-    private String userId1;
-    private String userId2;
+    private List<Participant> participants;
     private String lastMessage;
     private LocalDateTime lastMessageTime;
 
@@ -26,8 +26,7 @@ public class ChatRoomResponse {
     public static ChatRoomResponse from(ChatRoom chatRoom) {
         return ChatRoomResponse.builder()
                 .id(chatRoom.getId())
-                .userId1(chatRoom.getParticipants().getFirst())
-                .userId2(chatRoom.getParticipants().getLast())
+                .participants(chatRoom.getParticipants())
                 .lastMessage(chatRoom.getLastMessage().getContent())
                 .lastMessageTime(chatRoom.getLastMessage().getSentAt())
                 .build();

--- a/src/main/java/com/zip/community/platform/adapter/out/ChatMessageMongoPersistenceAdapter.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/ChatMessageMongoPersistenceAdapter.java
@@ -1,0 +1,74 @@
+package com.zip.community.platform.adapter.out;
+
+import com.zip.community.common.response.CustomException;
+import com.zip.community.common.response.errorcode.ChatErrorCode;
+import com.zip.community.platform.adapter.out.mongo.chat.ChatMessageDocument;
+import com.zip.community.platform.adapter.out.mongo.chat.ReportedChatMessageDocument;
+import com.zip.community.platform.adapter.out.mongo.chat.repository.ChatMessageMongoRepository;
+import com.zip.community.platform.adapter.out.mongo.chat.repository.ReportedChatMessageMongoRepository;
+import com.zip.community.platform.application.port.out.chat.ChatMessageMongoPort;
+import com.zip.community.platform.domain.chat.ChatMessage;
+import com.zip.community.platform.domain.report.ReportedChatMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class ChatMessageMongoPersistenceAdapter implements ChatMessageMongoPort {
+
+    private final ChatMessageMongoRepository chatMessageRepository;
+    private final ReportedChatMessageMongoRepository reportedChatMessageRepository;
+
+    @Override
+    public ChatMessage save(ChatMessage message) {
+        ChatMessageDocument doc = ChatMessageDocument.builder()
+                .id(message.getId())
+                .chatRoomId(message.getChatRoomId())
+                .content(message.getContent())
+                .senderId(message.getSenderId())
+                .senderName(message.getSenderName())
+                .sentAt(message.getSentAt())
+                .readYn(message.getReadYn())
+                .deletedYn(message.getDeletedYn())
+                .build();
+        ChatMessageDocument savedDoc = chatMessageRepository.save(doc);
+        return savedDoc.toDomain();
+    }
+
+    @Override
+    public List<ChatMessage> getMessages(String chatRoomId, Integer page) {
+        // page=0: 1~20, page=1: 21~40 ...
+        PageRequest pageable = PageRequest.of(page, 20);
+        List<ChatMessageDocument> docs =
+                chatMessageRepository.findByChatRoomIdOrderBySentAtDesc(chatRoomId, pageable);
+        return docs.stream().map(ChatMessageDocument::toDomain).collect(Collectors.toList());
+    }
+
+    @Override
+    public ChatMessage findById(String messageId) {
+        return chatMessageRepository.findById(messageId)
+                .orElseThrow(() -> new CustomException(ChatErrorCode.NOT_FOUND_CHAT_MESSAGE))
+                .toDomain();
+    }
+
+    @Override
+    public ReportedChatMessage reportMessage(String messageId, Long reportMemberId, Long reportedMemberId, String reason) {
+        return reportedChatMessageRepository.save(ReportedChatMessageDocument.builder()
+                .messageId(messageId)
+                .reportMemberId(reportMemberId)
+                .reportedMemberId(reportedMemberId)
+                .reason(reason)
+                .build()
+        ).toDomain();
+    }
+
+    @Override
+    public List<ChatMessage> searchMessages(String chatRoomId, String keyword) {
+        return null;
+    }
+}

--- a/src/main/java/com/zip/community/platform/adapter/out/ChatMessageMongoPersistenceAdapter.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/ChatMessageMongoPersistenceAdapter.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -58,6 +57,9 @@ public class ChatMessageMongoPersistenceAdapter implements ChatMessageMongoPort 
 
     @Override
     public ReportedChatMessage reportMessage(String messageId, Long reportMemberId, Long reportedMemberId, String reason) {
+        reportedChatMessageRepository.findByMessageIdAndReportMemberId(messageId, reportMemberId).ifPresent(doc -> {
+            throw new CustomException(ChatErrorCode.ALREADY_REPORTED_MESSAGE);
+        });
         return reportedChatMessageRepository.save(ReportedChatMessageDocument.builder()
                 .messageId(messageId)
                 .reportMemberId(reportMemberId)

--- a/src/main/java/com/zip/community/platform/adapter/out/ChatRoomMongoPersistenceAdapter.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/ChatRoomMongoPersistenceAdapter.java
@@ -1,0 +1,52 @@
+package com.zip.community.platform.adapter.out;
+
+import com.zip.community.platform.adapter.out.mongo.chat.ChatRoomDocument;
+import com.zip.community.platform.adapter.out.mongo.chat.repository.ChatRoomMongoRepository;
+import com.zip.community.platform.application.port.out.chat.ChatRoomPort;
+import com.zip.community.platform.domain.chat.ChatRoom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class ChatRoomMongoPersistenceAdapter implements ChatRoomPort {
+
+    private final ChatRoomMongoRepository chatRoomRepository;
+
+    @Override
+    public ChatRoom save(ChatRoom chatRoom) {
+        ChatRoomDocument doc = ChatRoomDocument.from(
+                chatRoom.getId(),
+                chatRoom.getParticipants(),
+                chatRoom.getLastMessage()
+        );
+        ChatRoomDocument savedDoc = chatRoomRepository.save(doc);
+        return savedDoc.toDomain();
+    }
+
+    @Override
+    public ChatRoom findByChatRoomId(String chatRoomId) {
+        return chatRoomRepository.findById(chatRoomId)
+                .map(ChatRoomDocument::toDomain)
+                .orElse(null);
+    }
+
+    @Override
+    public ChatRoom findChatRoomByParticipants(String userId1, String userId2) {
+        List<ChatRoomDocument> rooms = chatRoomRepository.findByParticipantsContaining(userId1);
+        return rooms.stream()
+                .filter(room -> room.getParticipants().contains(userId2))
+                .findFirst()
+                .map(ChatRoomDocument::toDomain)
+                .orElse(null);
+    }
+
+    @Override
+    public List<ChatRoom> findChatRoomsByUserId(String userId) {
+        List<ChatRoomDocument> rooms = chatRoomRepository.findByParticipantsContaining(userId);
+        return rooms.stream().map(ChatRoomDocument::toDomain).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/zip/community/platform/adapter/out/ChatRoomMongoPersistenceAdapter.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/ChatRoomMongoPersistenceAdapter.java
@@ -1,7 +1,5 @@
 package com.zip.community.platform.adapter.out;
 
-import com.zip.community.common.response.CustomException;
-import com.zip.community.common.response.errorcode.ChatErrorCode;
 import com.zip.community.platform.adapter.out.mongo.chat.ChatRoomDocument;
 import com.zip.community.platform.adapter.out.mongo.chat.repository.ChatRoomMongoRepository;
 import com.zip.community.platform.application.port.out.chat.ChatRoomPort;
@@ -10,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
@@ -20,28 +19,20 @@ public class ChatRoomMongoPersistenceAdapter implements ChatRoomPort {
 
     @Override
     public ChatRoom save(ChatRoom chatRoom) {
-        ChatRoomDocument doc = ChatRoomDocument.from(
-                chatRoom.getId(),
-                chatRoom.getParticipants(),
-                chatRoom.getLastMessage()
-        );
+        ChatRoomDocument doc = ChatRoomDocument.from(chatRoom);
         ChatRoomDocument savedDoc = chatRoomRepository.save(doc);
         return savedDoc.toDomain();
     }
 
     @Override
-    public ChatRoom findByChatRoomId(String chatRoomId) {
+    public Optional<ChatRoom> findByChatRoomId(String chatRoomId) {
         return chatRoomRepository.findById(chatRoomId)
-                .map(ChatRoomDocument::toDomain)
-                .orElseThrow(() -> new CustomException(ChatErrorCode.NOT_FOUND_CHAT_ROOM));
+                .map(ChatRoomDocument::toDomain);
     }
 
     @Override
     public List<ChatRoom> findChatRoomsByUserId(Long memberId) {
         List<ChatRoomDocument> rooms = chatRoomRepository.findByParticipantsId(memberId);
-        if (rooms == null || rooms.isEmpty()) {
-            throw new CustomException(ChatErrorCode.NOT_FOUND_CHAT_ROOM);
-        }
         return rooms.stream()
                 .map(ChatRoomDocument::toDomain)
                 .collect(Collectors.toList());

--- a/src/main/java/com/zip/community/platform/adapter/out/InMemBrokerAdapter.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/InMemBrokerAdapter.java
@@ -1,0 +1,27 @@
+package com.zip.community.platform.adapter.out;
+
+import com.zip.community.platform.application.port.out.chat.MessageSendPort;
+import com.zip.community.platform.domain.chat.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import static java.lang.String.format;
+
+@Slf4j
+@Component
+@Profile("test")
+@RequiredArgsConstructor
+public class InMemBrokerAdapter implements MessageSendPort {
+
+    private final SimpMessagingTemplate simpMessagingTemplate;
+
+    @Override
+    public ChatMessage send(ChatMessage message) {
+        simpMessagingTemplate.convertAndSend(format("/%s", message.getChatRoomId()), message);
+        log.info("인메모리 메세지 브로커 메세지 전송: " + message.getChatRoomId() + ": " + message.getContent());
+        return message;
+    }
+}

--- a/src/main/java/com/zip/community/platform/adapter/out/mongo/BaseDocument.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/mongo/BaseDocument.java
@@ -1,0 +1,17 @@
+package com.zip.community.platform.adapter.out.mongo;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Getter
+public abstract class BaseDocument {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/ChatMessageDocument.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/ChatMessageDocument.java
@@ -28,6 +28,19 @@ public class ChatMessageDocument extends BaseDocument {
     private Boolean readYn;
     private Boolean deletedYn;
 
+    public static ChatMessageDocument from(ChatMessage chatMessage) {
+        return ChatMessageDocument.builder()
+                .id(chatMessage.getId())
+                .chatRoomId(chatMessage.getChatRoomId())
+                .content(chatMessage.getContent())
+                .senderId(chatMessage.getSenderId())
+                .senderName(chatMessage.getSenderName())
+                .sentAt(chatMessage.getSentAt())
+                .readYn(chatMessage.getReadYn())
+                .deletedYn(chatMessage.getDeletedYn())
+                .build();
+    }
+
     public ChatMessage toDomain() {
         return ChatMessage.builder()
                 .id(this.id)

--- a/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/ChatMessageDocument.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/ChatMessageDocument.java
@@ -1,0 +1,43 @@
+package com.zip.community.platform.adapter.out.mongo.chat;
+
+import com.zip.community.platform.adapter.out.mongo.BaseDocument;
+import com.zip.community.platform.domain.chat.ChatMessage;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Document(collection = "chat_message")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatMessageDocument extends BaseDocument {
+
+    @Id
+    private String id;
+    private String chatRoomId;
+    private String content;
+    private Long senderId;
+    private String senderName;
+    private LocalDateTime sentAt;
+    private Boolean readYn;
+    private Boolean deletedYn;
+
+    public ChatMessage toDomain() {
+        return ChatMessage.builder()
+                .id(this.id)
+                .chatRoomId(this.chatRoomId)
+                .content(this.content)
+                .senderId(this.senderId)
+                .senderName(this.senderName)
+                .sentAt(this.sentAt)
+                .readYn(this.readYn)
+                .deletedYn(this.deletedYn)
+                .build();
+    }
+}

--- a/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/ChatRoomDocument.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/ChatRoomDocument.java
@@ -1,0 +1,42 @@
+package com.zip.community.platform.adapter.out.mongo.chat;
+
+import com.zip.community.platform.adapter.out.mongo.BaseDocument;
+import com.zip.community.platform.domain.chat.ChatRoom;
+import com.zip.community.platform.domain.chat.LastMessage;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document(collection = "chat_room")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatRoomDocument extends BaseDocument {
+
+    @Id
+    private String id;
+    private List<String> participants;
+    private LastMessage lastMessage;
+
+    public static ChatRoomDocument from(String id, List<String> participants, LastMessage lastMessage) {
+        return ChatRoomDocument.builder()
+                .id(id)
+                .participants(participants)
+                .lastMessage(lastMessage)
+                .build();
+    }
+
+    public ChatRoom toDomain() {
+        return ChatRoom.builder()
+                .id(this.id)
+                .participants(this.participants)
+                .lastMessage(this.lastMessage)
+                .build();
+    }
+}

--- a/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/ChatRoomDocument.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/ChatRoomDocument.java
@@ -25,11 +25,11 @@ public class ChatRoomDocument extends BaseDocument {
     private List<Participant> participants;
     private LastMessage lastMessage;
 
-    public static ChatRoomDocument from(String id, List<Participant> participants, LastMessage lastMessage) {
+    public static ChatRoomDocument from(ChatRoom chatRoom) {
         return ChatRoomDocument.builder()
-                .id(id)
-                .participants(participants)
-                .lastMessage(lastMessage)
+                .id(chatRoom.getId())
+                .participants(chatRoom.getParticipants())
+                .lastMessage(chatRoom.getLastMessage())
                 .build();
     }
 

--- a/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/ChatRoomDocument.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/ChatRoomDocument.java
@@ -3,6 +3,7 @@ package com.zip.community.platform.adapter.out.mongo.chat;
 import com.zip.community.platform.adapter.out.mongo.BaseDocument;
 import com.zip.community.platform.domain.chat.ChatRoom;
 import com.zip.community.platform.domain.chat.LastMessage;
+import com.zip.community.platform.domain.chat.Participant;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,10 +22,10 @@ public class ChatRoomDocument extends BaseDocument {
 
     @Id
     private String id;
-    private List<String> participants;
+    private List<Participant> participants;
     private LastMessage lastMessage;
 
-    public static ChatRoomDocument from(String id, List<String> participants, LastMessage lastMessage) {
+    public static ChatRoomDocument from(String id, List<Participant> participants, LastMessage lastMessage) {
         return ChatRoomDocument.builder()
                 .id(id)
                 .participants(participants)

--- a/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/ReportedChatMessageDocument.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/ReportedChatMessageDocument.java
@@ -23,6 +23,16 @@ public class ReportedChatMessageDocument extends BaseDocument {
     private Long reportedMemberId; // 신고당한 회원 ID
     private String reason;
 
+    public static ReportedChatMessageDocument from(ReportedChatMessage reportedChatMessage) {
+        return ReportedChatMessageDocument.builder()
+                .id(reportedChatMessage.getId())
+                .messageId(reportedChatMessage.getMessageId())
+                .reportMemberId(reportedChatMessage.getReportMemberId())
+                .reportedMemberId(reportedChatMessage.getReportedMemberId())
+                .reason(reportedChatMessage.getReason())
+                .build();
+    }
+
     public ReportedChatMessage toDomain() {
         return ReportedChatMessage.builder()
                 .id(this.id)

--- a/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/ReportedChatMessageDocument.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/ReportedChatMessageDocument.java
@@ -1,0 +1,36 @@
+package com.zip.community.platform.adapter.out.mongo.chat;
+
+import com.zip.community.platform.adapter.out.mongo.BaseDocument;
+import com.zip.community.platform.domain.report.ReportedChatMessage;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "reported_message")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReportedChatMessageDocument extends BaseDocument {
+
+    @Id
+    private String id;
+    private String messageId;
+    private Long reportMemberId;   // 신고한 회원 ID
+    private Long reportedMemberId; // 신고당한 회원 ID
+    private String reason;
+
+    public ReportedChatMessage toDomain() {
+        return ReportedChatMessage.builder()
+                .id(this.id)
+                .messageId(this.messageId)
+                .reportMemberId(this.reportMemberId)
+                .reportedMemberId(this.reportedMemberId)
+                .reason(this.reason)
+                .reportedAt(this.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/repository/ChatMessageMongoRepository.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/repository/ChatMessageMongoRepository.java
@@ -1,0 +1,15 @@
+package com.zip.community.platform.adapter.out.mongo.chat.repository;
+
+import com.zip.community.platform.adapter.out.mongo.chat.ChatMessageDocument;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ChatMessageMongoRepository extends MongoRepository<ChatMessageDocument, String> {
+
+    // 채팅방 내역 조회용 메소드: 채팅방 ID 기준으로 sentAt 내림차순 정렬 후 페이징 처리
+    List<ChatMessageDocument> findByChatRoomIdOrderBySentAtDesc(String chatRoomId, Pageable pageable);
+    List<ChatMessageDocument> findByChatRoomIdAndContentContainingOrderBySentAtDesc(String chatRoomId, String keyword, Pageable pageable);
+}

--- a/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/repository/ChatRoomMongoRepository.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/repository/ChatRoomMongoRepository.java
@@ -1,0 +1,11 @@
+package com.zip.community.platform.adapter.out.mongo.chat.repository;
+
+import com.zip.community.platform.adapter.out.mongo.chat.ChatRoomDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface ChatRoomMongoRepository extends MongoRepository<ChatRoomDocument, String> {
+
+    List<ChatRoomDocument> findByParticipantsContaining(String userId);
+}

--- a/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/repository/ChatRoomMongoRepository.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/repository/ChatRoomMongoRepository.java
@@ -2,10 +2,13 @@ package com.zip.community.platform.adapter.out.mongo.chat.repository;
 
 import com.zip.community.platform.adapter.out.mongo.chat.ChatRoomDocument;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
 import java.util.List;
 
 public interface ChatRoomMongoRepository extends MongoRepository<ChatRoomDocument, String> {
 
-    List<ChatRoomDocument> findByParticipantsContaining(String userId);
+    List<ChatRoomDocument> findByParticipantsId(Long memberId);
+    @Query("{ 'participants.id': { $all: [?0, ?1] } }")
+    List<ChatRoomDocument> findByParticipantsContainingBoth(Long senderId, Long receiverId);
 }

--- a/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/repository/ReportedChatMessageMongoRepository.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/repository/ReportedChatMessageMongoRepository.java
@@ -3,5 +3,9 @@ package com.zip.community.platform.adapter.out.mongo.chat.repository;
 import com.zip.community.platform.adapter.out.mongo.chat.ReportedChatMessageDocument;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.Optional;
+
 public interface ReportedChatMessageMongoRepository extends MongoRepository<ReportedChatMessageDocument, String> {
+
+    Optional<ReportedChatMessageDocument> findByMessageIdAndReportMemberId(String messageId, Long reportMemberId);
 }

--- a/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/repository/ReportedChatMessageMongoRepository.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/repository/ReportedChatMessageMongoRepository.java
@@ -1,0 +1,7 @@
+package com.zip.community.platform.adapter.out.mongo.chat.repository;
+
+import com.zip.community.platform.adapter.out.mongo.chat.ReportedChatMessageDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ReportedChatMessageMongoRepository extends MongoRepository<ReportedChatMessageDocument, String> {
+}

--- a/src/main/java/com/zip/community/platform/application/port/in/chat/ChatMessageUseCase.java
+++ b/src/main/java/com/zip/community/platform/application/port/in/chat/ChatMessageUseCase.java
@@ -1,0 +1,17 @@
+package com.zip.community.platform.application.port.in.chat;
+
+import com.zip.community.platform.domain.chat.ChatMessage;
+import com.zip.community.platform.domain.report.ReportedChatMessage;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ChatMessageUseCase {
+
+    ChatMessage sendMessage(ChatMessage message);
+    List<ChatMessage> getMessages(String chatRoomId, Integer page);
+    ChatMessage deleteMessage(String messageId, Long memberId);
+    ReportedChatMessage reportMessage(String messageId, Long reportMemberId, Long reportedMemberId, String reason);
+    ChatMessage blockMessage(String messageId);
+    List<ChatMessage> searchMessages(String chatRoomId, String keyword);
+}

--- a/src/main/java/com/zip/community/platform/application/port/in/chat/ChatRoomUseCase.java
+++ b/src/main/java/com/zip/community/platform/application/port/in/chat/ChatRoomUseCase.java
@@ -1,0 +1,10 @@
+package com.zip.community.platform.application.port.in.chat;
+
+import com.zip.community.platform.domain.chat.ChatRoom;
+
+import java.util.List;
+
+public interface ChatRoomUseCase {
+    ChatRoom startChat(String userId1, String userId2);
+    List<ChatRoom> getChatRoomsForUser(String userId);
+}

--- a/src/main/java/com/zip/community/platform/application/port/in/chat/ChatRoomUseCase.java
+++ b/src/main/java/com/zip/community/platform/application/port/in/chat/ChatRoomUseCase.java
@@ -5,6 +5,6 @@ import com.zip.community.platform.domain.chat.ChatRoom;
 import java.util.List;
 
 public interface ChatRoomUseCase {
-    ChatRoom startChat(String userId1, String userId2);
-    List<ChatRoom> getChatRoomsForUser(String userId);
+    ChatRoom startChat(Long senderId, Long receiverId, String senderName, String receiverName);
+    List<ChatRoom> getChatRoomsForUser(Long memberId);
 }

--- a/src/main/java/com/zip/community/platform/application/port/out/chat/ChatMessageMongoPort.java
+++ b/src/main/java/com/zip/community/platform/application/port/out/chat/ChatMessageMongoPort.java
@@ -1,15 +1,19 @@
 package com.zip.community.platform.application.port.out.chat;
 
+import com.zip.community.platform.adapter.out.mongo.chat.ChatMessageDocument;
+import com.zip.community.platform.adapter.out.mongo.chat.ReportedChatMessageDocument;
 import com.zip.community.platform.domain.chat.ChatMessage;
 import com.zip.community.platform.domain.report.ReportedChatMessage;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatMessageMongoPort {
 
     ChatMessage save(ChatMessage message);
     List<ChatMessage> getMessages(String chatRoomId, Integer page);
-    ChatMessage findById(String messageId);
-    ReportedChatMessage reportMessage(String messageId, Long reportMemberId, Long reportedMemberId, String reason);
+    Optional<ChatMessageDocument> findById(String messageId);
+    ReportedChatMessage reportMessage(ReportedChatMessage reportedChatMessage);
     List<ChatMessage> searchMessages(String chatRoomId, String keyword);
+    Optional<ReportedChatMessageDocument> getByMessageIdAndReportMemberId(String messageId, Long reportMemberId);
 }

--- a/src/main/java/com/zip/community/platform/application/port/out/chat/ChatMessageMongoPort.java
+++ b/src/main/java/com/zip/community/platform/application/port/out/chat/ChatMessageMongoPort.java
@@ -1,0 +1,16 @@
+package com.zip.community.platform.application.port.out.chat;
+
+import com.zip.community.platform.domain.chat.ChatMessage;
+import com.zip.community.platform.domain.report.ReportedChatMessage;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ChatMessageMongoPort {
+
+    ChatMessage save(ChatMessage message);
+    List<ChatMessage> getMessages(String chatRoomId, Integer page);
+    ChatMessage findById(String messageId);
+    ReportedChatMessage reportMessage(String messageId, Long reportMemberId, Long reportedMemberId, String reason);
+    List<ChatMessage> searchMessages(String chatRoomId, String keyword);
+}

--- a/src/main/java/com/zip/community/platform/application/port/out/chat/ChatMessageMongoPort.java
+++ b/src/main/java/com/zip/community/platform/application/port/out/chat/ChatMessageMongoPort.java
@@ -3,7 +3,6 @@ package com.zip.community.platform.application.port.out.chat;
 import com.zip.community.platform.domain.chat.ChatMessage;
 import com.zip.community.platform.domain.report.ReportedChatMessage;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ChatMessageMongoPort {

--- a/src/main/java/com/zip/community/platform/application/port/out/chat/ChatRoomPort.java
+++ b/src/main/java/com/zip/community/platform/application/port/out/chat/ChatRoomPort.java
@@ -1,0 +1,13 @@
+package com.zip.community.platform.application.port.out.chat;
+
+import com.zip.community.platform.domain.chat.ChatRoom;
+
+import java.util.List;
+
+public interface ChatRoomPort {
+
+    ChatRoom save(ChatRoom chatRoom);
+    ChatRoom findByChatRoomId(String chatRoomId);
+    ChatRoom findChatRoomByParticipants(String userId1, String userId2);
+    List<ChatRoom> findChatRoomsByUserId(String userId);
+}

--- a/src/main/java/com/zip/community/platform/application/port/out/chat/ChatRoomPort.java
+++ b/src/main/java/com/zip/community/platform/application/port/out/chat/ChatRoomPort.java
@@ -3,11 +3,12 @@ package com.zip.community.platform.application.port.out.chat;
 import com.zip.community.platform.domain.chat.ChatRoom;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatRoomPort {
 
     ChatRoom save(ChatRoom chatRoom);
-    ChatRoom findByChatRoomId(String chatRoomId);
+    Optional<ChatRoom> findByChatRoomId(String chatRoomId);
     List<ChatRoom> findChatRoomsByUserId(Long memberId);
     ChatRoom findChatRoomByParticipants(Long senderId, Long receiverId);
 }

--- a/src/main/java/com/zip/community/platform/application/port/out/chat/ChatRoomPort.java
+++ b/src/main/java/com/zip/community/platform/application/port/out/chat/ChatRoomPort.java
@@ -8,6 +8,6 @@ public interface ChatRoomPort {
 
     ChatRoom save(ChatRoom chatRoom);
     ChatRoom findByChatRoomId(String chatRoomId);
-    ChatRoom findChatRoomByParticipants(String userId1, String userId2);
-    List<ChatRoom> findChatRoomsByUserId(String userId);
+    List<ChatRoom> findChatRoomsByUserId(Long memberId);
+    ChatRoom findChatRoomByParticipants(Long senderId, Long receiverId);
 }

--- a/src/main/java/com/zip/community/platform/application/port/out/chat/MessageSendPort.java
+++ b/src/main/java/com/zip/community/platform/application/port/out/chat/MessageSendPort.java
@@ -1,0 +1,8 @@
+package com.zip.community.platform.application.port.out.chat;
+
+import com.zip.community.platform.domain.chat.ChatMessage;
+
+public interface MessageSendPort {
+
+    ChatMessage send(ChatMessage message);
+}

--- a/src/main/java/com/zip/community/platform/application/service/chat/ChatMessageService.java
+++ b/src/main/java/com/zip/community/platform/application/service/chat/ChatMessageService.java
@@ -1,0 +1,96 @@
+package com.zip.community.platform.application.service.chat;
+
+import com.zip.community.common.response.CustomException;
+import com.zip.community.common.response.errorcode.ChatErrorCode;
+import com.zip.community.platform.application.port.in.chat.ChatMessageUseCase;
+import com.zip.community.platform.application.port.out.chat.ChatMessageMongoPort;
+import com.zip.community.platform.application.port.out.chat.ChatRoomPort;
+import com.zip.community.platform.application.port.out.chat.MessageSendPort;
+import com.zip.community.platform.domain.chat.ChatMessage;
+import com.zip.community.platform.domain.chat.ChatRoom;
+import com.zip.community.platform.domain.report.ReportedChatMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatMessageService implements ChatMessageUseCase {
+
+    private final ChatRoomPort chatRoomPort;
+    private final ChatMessageMongoPort chatMessageMongoPort;
+    private final MessageSendPort messageSendPort;
+
+    @Override
+    public ChatMessage sendMessage(ChatMessage message) {
+
+        // 채팅방 존재 확인
+        ChatRoom byChatRoomId = chatRoomPort.findByChatRoomId(message.getChatRoomId());
+        if (byChatRoomId == null) {
+            throw new CustomException(ChatErrorCode.NOT_FOUND_CHAT_ROOM);
+        }
+
+        ChatMessage savedMessage = chatMessageMongoPort.save(message);
+        return messageSendPort.send(savedMessage);
+    }
+
+    @Override
+    public List<ChatMessage> getMessages(String chatRoomId, Integer page) {
+        return chatMessageMongoPort.getMessages(chatRoomId, page);
+    }
+
+    @Override
+    public ChatMessage deleteMessage(String messageId, Long memberId) {
+
+        ChatMessage message = chatMessageMongoPort.findById(messageId);
+        if (!message.getSenderId().equals(memberId)) return message;
+
+        message.setContent("삭제된 메세지입니다");
+        message.setDeletedYn(true);
+
+        return chatMessageMongoPort.save(message);
+    }
+
+    @Override
+    public ReportedChatMessage reportMessage(String messageId, Long reportMemberId, Long reportedMemberId, String reason) {
+
+        ChatMessage message = chatMessageMongoPort.findById(messageId);
+
+        // 이미 삭제된 메세지인 경우 예외처리
+        if(message.getDeletedYn()) {
+            throw new CustomException(ChatErrorCode.ALREADY_DELETED_MESSAGE);
+        }
+
+        // 신고한 사람과 신고당한 사람이 같으면 예외처리
+        if (reportMemberId.equals(reportedMemberId)) {
+            throw new CustomException(ChatErrorCode.REPORT_SAME_MEMBER);
+        }
+        return chatMessageMongoPort.reportMessage(messageId, reportMemberId, reportedMemberId, reason);
+    }
+
+    @Override
+    public ChatMessage blockMessage(String messageId) {
+
+        ChatMessage message = chatMessageMongoPort.findById(messageId);
+        // 이미 삭제된 메세지인 경우 예외처리
+        if(message.getDeletedYn()) {
+            throw new CustomException(ChatErrorCode.ALREADY_DELETED_MESSAGE);
+        }
+
+        message.setContent("부적절한 내용으로 차단된 메세지입니다");
+        message.setDeletedYn(true);
+
+        return chatMessageMongoPort.save(message);
+    }
+
+    // 해야함
+    @Override
+    public List<ChatMessage> searchMessages(String chatRoomId, String keyword) {
+        return chatMessageMongoPort.searchMessages(chatRoomId, keyword);
+    }
+}

--- a/src/main/java/com/zip/community/platform/application/service/chat/ChatRoomService.java
+++ b/src/main/java/com/zip/community/platform/application/service/chat/ChatRoomService.java
@@ -1,0 +1,37 @@
+package com.zip.community.platform.application.service.chat;
+
+import com.zip.community.platform.application.port.in.chat.ChatRoomUseCase;
+import com.zip.community.platform.application.port.out.chat.ChatRoomPort;
+import com.zip.community.platform.domain.chat.ChatRoom;
+import com.zip.community.platform.domain.chat.LastMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatRoomService implements ChatRoomUseCase {
+
+    private final ChatRoomPort chatRoomPort;
+
+    @Override
+    public ChatRoom startChat(String userId1, String userId2) {
+        ChatRoom existing = chatRoomPort.findChatRoomByParticipants(userId1, userId2);
+        if (existing != null) {
+            return existing;
+        }
+        ChatRoom chatRoom = ChatRoom.builder()
+                .participants(List.of(userId1, userId2))
+                .lastMessage(LastMessage.builder().content("채팅이 시작되었습니다.").build())
+                .build();
+        return chatRoomPort.save(chatRoom);
+    }
+
+    @Override
+    public List<ChatRoom> getChatRoomsForUser(String userId) {
+        return chatRoomPort.findChatRoomsByUserId(userId);
+    }
+}

--- a/src/main/java/com/zip/community/platform/application/service/chat/ChatRoomService.java
+++ b/src/main/java/com/zip/community/platform/application/service/chat/ChatRoomService.java
@@ -1,7 +1,10 @@
 package com.zip.community.platform.application.service.chat;
 
+import com.zip.community.common.response.CustomException;
+import com.zip.community.common.response.errorcode.ChatErrorCode;
 import com.zip.community.platform.application.port.in.chat.ChatRoomUseCase;
 import com.zip.community.platform.application.port.out.chat.ChatRoomPort;
+import com.zip.community.platform.application.port.out.member.MemberPort;
 import com.zip.community.platform.domain.chat.ChatRoom;
 import com.zip.community.platform.domain.chat.LastMessage;
 import com.zip.community.platform.domain.chat.Participant;
@@ -9,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -17,25 +21,40 @@ import java.util.List;
 public class ChatRoomService implements ChatRoomUseCase {
 
     private final ChatRoomPort chatRoomPort;
+    private final MemberPort memberPort;
 
     @Override
     public ChatRoom startChat(Long senderId, Long receiverId, String senderName, String receiverName) {
+
+        checkExistMember(senderId);
 
         ChatRoom existing = chatRoomPort.findChatRoomByParticipants(senderId, receiverId);
         if (existing != null) {
             return existing;
         }
-        Participant p1 = Participant.builder().id(senderId).name(senderName).build();
-        Participant p2 = Participant.builder().id(receiverId).name(receiverName).build();
-        ChatRoom chatRoom = ChatRoom.builder()
-                .participants(List.of(p1, p2))
-                .lastMessage(LastMessage.builder().content("채팅이 시작되었습니다.").build())
-                .build();
+        Participant p1 = Participant.of(senderId, senderName);
+        Participant p2 = Participant.of(receiverId, receiverName);
+        ChatRoom chatRoom = ChatRoom.of(List.of(p1, p2), LastMessage.of("채팅이 시작되었습니다.", "system", LocalDateTime.now()));
+
         return chatRoomPort.save(chatRoom);
     }
 
     @Override
     public List<ChatRoom> getChatRoomsForUser(Long memberId) {
-        return chatRoomPort.findChatRoomsByUserId(memberId);
+
+        checkExistMember(memberId);
+
+        List<ChatRoom> chatRooms = chatRoomPort.findChatRoomsByUserId(memberId);
+        if(chatRooms.isEmpty()) {
+            throw new CustomException(ChatErrorCode.NOT_FOUND_CHAT_ROOM);
+        }
+        return chatRooms;
+    }
+
+    private void checkExistMember(Long memberId) {
+        boolean checkedExistUser = memberPort.getCheckedExistUser(memberId);
+        if (!checkedExistUser) {
+            throw new CustomException(ChatErrorCode.NOT_FOUND_MEMBER);
+        }
     }
 }

--- a/src/main/java/com/zip/community/platform/application/service/chat/ChatRoomService.java
+++ b/src/main/java/com/zip/community/platform/application/service/chat/ChatRoomService.java
@@ -1,7 +1,5 @@
 package com.zip.community.platform.application.service.chat;
 
-import com.zip.community.common.response.CustomException;
-import com.zip.community.common.response.errorcode.ChatErrorCode;
 import com.zip.community.platform.application.port.in.chat.ChatRoomUseCase;
 import com.zip.community.platform.application.port.out.chat.ChatRoomPort;
 import com.zip.community.platform.domain.chat.ChatRoom;

--- a/src/main/java/com/zip/community/platform/application/service/chat/ChatRoomService.java
+++ b/src/main/java/com/zip/community/platform/application/service/chat/ChatRoomService.java
@@ -1,9 +1,12 @@
 package com.zip.community.platform.application.service.chat;
 
+import com.zip.community.common.response.CustomException;
+import com.zip.community.common.response.errorcode.ChatErrorCode;
 import com.zip.community.platform.application.port.in.chat.ChatRoomUseCase;
 import com.zip.community.platform.application.port.out.chat.ChatRoomPort;
 import com.zip.community.platform.domain.chat.ChatRoom;
 import com.zip.community.platform.domain.chat.LastMessage;
+import com.zip.community.platform.domain.chat.Participant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,20 +21,23 @@ public class ChatRoomService implements ChatRoomUseCase {
     private final ChatRoomPort chatRoomPort;
 
     @Override
-    public ChatRoom startChat(String userId1, String userId2) {
-        ChatRoom existing = chatRoomPort.findChatRoomByParticipants(userId1, userId2);
+    public ChatRoom startChat(Long senderId, Long receiverId, String senderName, String receiverName) {
+
+        ChatRoom existing = chatRoomPort.findChatRoomByParticipants(senderId, receiverId);
         if (existing != null) {
             return existing;
         }
+        Participant p1 = Participant.builder().id(senderId).name(senderName).build();
+        Participant p2 = Participant.builder().id(receiverId).name(receiverName).build();
         ChatRoom chatRoom = ChatRoom.builder()
-                .participants(List.of(userId1, userId2))
+                .participants(List.of(p1, p2))
                 .lastMessage(LastMessage.builder().content("채팅이 시작되었습니다.").build())
                 .build();
         return chatRoomPort.save(chatRoom);
     }
 
     @Override
-    public List<ChatRoom> getChatRoomsForUser(String userId) {
-        return chatRoomPort.findChatRoomsByUserId(userId);
+    public List<ChatRoom> getChatRoomsForUser(Long memberId) {
+        return chatRoomPort.findChatRoomsByUserId(memberId);
     }
 }

--- a/src/main/java/com/zip/community/platform/domain/chat/ChatMessage.java
+++ b/src/main/java/com/zip/community/platform/domain/chat/ChatMessage.java
@@ -2,13 +2,11 @@ package com.zip.community.platform.domain.chat;
 
 import com.zip.community.platform.domain.BaseDomain;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
 @SuperBuilder
 public class ChatMessage extends BaseDomain {
 
@@ -20,4 +18,26 @@ public class ChatMessage extends BaseDomain {
     private LocalDateTime sentAt;
     private Boolean readYn;
     private Boolean deletedYn;
+
+    public static ChatMessage of(String chatRoomId, String content, Long senderId, String senderName, LocalDateTime sentAt, Boolean readYn, Boolean deletedYn) {
+        return ChatMessage.builder()
+                .chatRoomId(chatRoomId)
+                .content(content)
+                .senderId(senderId)
+                .senderName(senderName)
+                .sentAt(sentAt)
+                .readYn(readYn)
+                .deletedYn(deletedYn)
+                .build();
+    }
+
+    public void delete() {
+        this.content = "삭제된 메세지입니다";
+        this.deletedYn = true;
+    }
+
+    public void block() {
+        this.content = "부적절한 내용으로 차단된 메세지입니다";
+        this.deletedYn = true;
+    }
 }

--- a/src/main/java/com/zip/community/platform/domain/chat/ChatMessage.java
+++ b/src/main/java/com/zip/community/platform/domain/chat/ChatMessage.java
@@ -1,0 +1,23 @@
+package com.zip.community.platform.domain.chat;
+
+import com.zip.community.platform.domain.BaseDomain;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@SuperBuilder
+public class ChatMessage extends BaseDomain {
+
+    private String id;
+    private String chatRoomId;
+    private String content;
+    private Long senderId;
+    private String senderName;
+    private LocalDateTime sentAt;
+    private Boolean readYn;
+    private Boolean deletedYn;
+}

--- a/src/main/java/com/zip/community/platform/domain/chat/ChatRoom.java
+++ b/src/main/java/com/zip/community/platform/domain/chat/ChatRoom.java
@@ -1,0 +1,27 @@
+package com.zip.community.platform.domain.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatRoom {
+
+    private String id;
+    private List<String> participants;
+    private LastMessage lastMessage;
+
+    private static ChatRoom of(String id, List<String> participants, LastMessage lastMessage) {
+        return ChatRoom.builder()
+                .id(id)
+                .participants(participants)
+                .lastMessage(lastMessage)
+                .build();
+    }
+}

--- a/src/main/java/com/zip/community/platform/domain/chat/ChatRoom.java
+++ b/src/main/java/com/zip/community/platform/domain/chat/ChatRoom.java
@@ -13,4 +13,11 @@ public class ChatRoom extends BaseDomain {
     private String id;
     private List<Participant> participants;
     private LastMessage lastMessage;
+
+    public static ChatRoom of(List<Participant> participants, LastMessage lastMessage) {
+        return ChatRoom.builder()
+                .participants(participants)
+                .lastMessage(lastMessage)
+                .build();
+    }
 }

--- a/src/main/java/com/zip/community/platform/domain/chat/ChatRoom.java
+++ b/src/main/java/com/zip/community/platform/domain/chat/ChatRoom.java
@@ -1,17 +1,14 @@
 package com.zip.community.platform.domain.chat;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import com.zip.community.platform.domain.BaseDomain;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
 @Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
-public class ChatRoom {
+@SuperBuilder
+public class ChatRoom extends BaseDomain {
 
     private String id;
     private List<Participant> participants;

--- a/src/main/java/com/zip/community/platform/domain/chat/LastMessage.java
+++ b/src/main/java/com/zip/community/platform/domain/chat/LastMessage.java
@@ -1,0 +1,20 @@
+package com.zip.community.platform.domain.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LastMessage {
+
+    private String content;
+    private String sender;
+    private LocalDateTime sentAt;
+
+}

--- a/src/main/java/com/zip/community/platform/domain/chat/LastMessage.java
+++ b/src/main/java/com/zip/community/platform/domain/chat/LastMessage.java
@@ -17,4 +17,11 @@ public class LastMessage {
     private String sender;
     private LocalDateTime sentAt;
 
+    public static LastMessage of(String content, String sender, LocalDateTime sentAt) {
+        return LastMessage.builder()
+                .content(content)
+                .sender(sender)
+                .sentAt(sentAt)
+                .build();
+    }
 }

--- a/src/main/java/com/zip/community/platform/domain/chat/Participant.java
+++ b/src/main/java/com/zip/community/platform/domain/chat/Participant.java
@@ -13,4 +13,11 @@ public class Participant {
 
     private Long id;
     private String name;
+
+    public static Participant of(Long id, String name) {
+        return Participant.builder()
+                .id(id)
+                .name(name)
+                .build();
+    }
 }

--- a/src/main/java/com/zip/community/platform/domain/chat/Participant.java
+++ b/src/main/java/com/zip/community/platform/domain/chat/Participant.java
@@ -5,15 +5,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class ChatRoom {
+public class Participant {
 
-    private String id;
-    private List<Participant> participants;
-    private LastMessage lastMessage;
+    private Long id;
+    private String name;
 }

--- a/src/main/java/com/zip/community/platform/domain/report/ReportedChatMessage.java
+++ b/src/main/java/com/zip/community/platform/domain/report/ReportedChatMessage.java
@@ -1,0 +1,19 @@
+package com.zip.community.platform.domain.report;
+
+import com.zip.community.platform.domain.BaseDomain;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Getter
+@SuperBuilder
+public class ReportedChatMessage extends BaseDomain {
+
+    private String id;
+    private String messageId;
+    private Long reportMemberId;
+    private Long reportedMemberId;
+    private String reason;
+    private LocalDateTime reportedAt;
+}

--- a/src/main/java/com/zip/community/platform/domain/report/ReportedChatMessage.java
+++ b/src/main/java/com/zip/community/platform/domain/report/ReportedChatMessage.java
@@ -16,4 +16,14 @@ public class ReportedChatMessage extends BaseDomain {
     private Long reportedMemberId;
     private String reason;
     private LocalDateTime reportedAt;
+
+    public static ReportedChatMessage of(String messageId, Long reportMemberId, Long reportedMemberId, String reason, LocalDateTime reportedAt) {
+        return ReportedChatMessage.builder()
+                .messageId(messageId)
+                .reportMemberId(reportMemberId)
+                .reportedMemberId(reportedMemberId)
+                .reason(reason)
+                .reportedAt(reportedAt)
+                .build();
+    }
 }


### PR DESCRIPTION
## 📌 작업한 내용  
- 두 사용자가 새로운 1:1 대화를 시작할 수 있으며, 기존에 대화가 있다면 기존 내역을 이어서 확인하거나 관리할 수 있는 기능 추가
- 사용자가 참여중인 1:1 채팅방 목록을 조회할 수 있는 기능 추가
- 텍스트(이모지 포함)를 전송하고, 상대방이 실시간으로 메세지를 수신할 수 있도록 하는 기능, 실시간 전송 및 수신 위해 WebSocket, STOMP 사용
- 채팅방 내 메세지 조회 기능 추가, 20개씩 보낸 시간 내림차순으로 반환 되며 페이징 처리하여 `page=0`인 경우 1\~20, `page=1`인 경우 21\~40 ... 이 순서로 값을 조회할 수 있음 
- 사용자가 자신이 전송한 메시지를 삭제하는 기능 추가, 실제 삭제 X, `삭제된메세지입니다`로 수정됨
- 특정 메세지를 신고하여 관리자가 해당 메세지 확인 후 차단 및 삭제 처리하는 기능 추가
  - 이미 삭제된 메세지는 신고 불가
  - 이미 차단된 메세지는 신고 불가
  - 이미 신고한 메세지는 중복 신고 불가

## 🔍 참고 사항  
- 읽음여부 및 알림 기능은 알림센터 진행시 같이 진행하려고합니다.
- 검색기능은 아직 미구현 상태이고 바로 구현할 예정입니다.

## 🖼️ 스크린샷  
#### 아키텍처
<img width="793" alt="스크린샷 2025-03-13 오전 12 05 08" src="https://github.com/user-attachments/assets/877b7269-8092-4138-9422-85add7680e9e" />

#### Document
<img width="938" alt="스크린샷 2025-03-13 오전 12 05 31" src="https://github.com/user-attachments/assets/01308229-4e2a-4488-8233-b276fe95bc75" />

#### TEST
채팅방생성
<img width="627" alt="스크린샷 2025-03-12 오후 11 56 23" src="https://github.com/user-attachments/assets/61bc29d5-a2c6-4263-be73-c5807b199d29" />
채팅방 목록조회 - data필드에 채팅방 객체가 리스트로 들어감
<img width="685" alt="스크린샷 2025-03-12 오후 11 57 45" src="https://github.com/user-attachments/assets/3bb86dbf-5963-44af-abbc-d11767fabf95" />
채팅 메세지 삭제
<img width="488" alt="스크린샷 2025-03-12 오후 11 58 35" src="https://github.com/user-attachments/assets/f0854e64-b3ab-4c8f-9232-0957943feb49" />
채팅 메세지 차단
<img width="526" alt="스크린샷 2025-03-13 오전 12 00 00" src="https://github.com/user-attachments/assets/350aea06-2d26-4785-96f5-13b0ae2531bb" />
채팅 메세지 신고
<img width="526" alt="스크린샷 2025-03-13 오전 12 00 55" src="https://github.com/user-attachments/assets/e85cfa5f-ce14-4cc0-b8ab-1cb12c5fc523" />
채팅 메세지 조회
<img width="645" alt="스크린샷 2025-03-13 오전 12 01 26" src="https://github.com/user-attachments/assets/735b1137-b525-472a-916f-cb315a630a19" />
메세지 전송 - STOMP 테스트해보는 js 코드 사용해서 테스트 했습니다.
<img width="1315" alt="스크린샷 2025-03-13 오전 12 06 46" src="https://github.com/user-attachments/assets/86950a6f-91fd-4b5a-b13a-770d9ea56cbc" />
```
// 관련로그
2025-03-13T00:08:06.752+09:00  INFO 65533 --- [boundChannel-10] .z.c.p.a.i.w.ChatMessageSocketController : 받은 메세지 67d05fbfbeb3372d35e1efbf: 안녕하세요3
2025-03-13T00:08:06.995+09:00  INFO 65533 --- [boundChannel-10] c.z.c.p.adapter.out.InMemBrokerAdapter   : 인메모리 메세지 브로커 메세지 전송: 67d05fbfbeb3372d35e1efbf: 안녕하세요3
```

## 🔗 관련 이슈  
[feat: 채팅 기능 구현 #5](https://github.com/ZiP-Official/Community-server/issues/5#issue-2904597817)

## ✅ 체크리스트  
- [x] 로컬에서 빌드 및 테스트 완료  
- [x] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
