### PR TITLE
✨feat: 채팅 메세지 검색기능 구현

### DIFF
--- a/src/main/java/com/zip/community/common/response/errorcode/ChatErrorCode.java
+++ b/src/main/java/com/zip/community/common/response/errorcode/ChatErrorCode.java
@@ -15,7 +15,8 @@ public enum ChatErrorCode implements ErrorCode {
     CHAT_ROOM_CREATION_FAILED(3004, HttpStatus.INTERNAL_SERVER_ERROR, "채팅방 생성에 실패했습니다."),
     REPORT_SAME_MEMBER(3005, HttpStatus.BAD_REQUEST, "자신을 신고할 수 없습니다."),
     ALREADY_DELETED_MESSAGE(3006, HttpStatus.BAD_REQUEST, "이미 삭제된 메세지입니다."),
-    ALREADY_REPORTED_MESSAGE(3007, HttpStatus.BAD_REQUEST, "이미 신고한 메세지입니다.");
+    ALREADY_REPORTED_MESSAGE(3007, HttpStatus.BAD_REQUEST, "이미 신고한 메세지입니다."),
+    INVALID_DIRECTION(3008, HttpStatus.BAD_REQUEST, "direction 값이 잘못되었습니다.");
 
     private final Integer code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/zip/community/platform/adapter/in/web/ChatMessageController.java
+++ b/src/main/java/com/zip/community/platform/adapter/in/web/ChatMessageController.java
@@ -3,6 +3,7 @@ package com.zip.community.platform.adapter.in.web;
 import com.zip.community.common.response.ApiResponse;
 import com.zip.community.platform.adapter.in.web.dto.request.chat.MessageDeleteRequest;
 import com.zip.community.platform.adapter.in.web.dto.request.chat.MessageReportRequest;
+import com.zip.community.platform.adapter.in.web.dto.response.chat.SearchResponse;
 import com.zip.community.platform.application.port.in.chat.ChatMessageUseCase;
 import com.zip.community.platform.domain.chat.ChatMessage;
 import com.zip.community.platform.domain.report.ReportedChatMessage;
@@ -11,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestController
@@ -21,10 +23,21 @@ public class ChatMessageController {
     private final ChatMessageUseCase chatMessageUseCase;
 
     // 채팅방 메세지 조회
+    // 초기 - 최신 메세지 20개 조회
+    // 이전 메세지 조회 - cursor 이전 메세지 pageSize 만큼 조회, direction: older
+    // 이후 메세지 조회 - cursor 이후 메세지 pageSize 만큼 조회, direction: newer
+    // includeCursor: false -> cursor 미포함, 메세지 조회할 때 사용, 채팅방 내에서 스크롤 시 사용
+    // includeCursor: true -> cursor 포함, 메세지 검색 후 해당 메세지 조회할 때 사용
     @GetMapping("/messages")
-    public ApiResponse<List<ChatMessage>> getMessages(@RequestParam String chatRoomId,
-                                                      @RequestParam(defaultValue = "0") Integer page) {
-        return ApiResponse.created(chatMessageUseCase.getMessages(chatRoomId, page));
+    public ApiResponse<List<ChatMessage>> getMessages(
+            @RequestParam String chatRoomId,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") Integer pageSize,
+            @RequestParam(defaultValue = "older") String direction,
+            @RequestParam(defaultValue = "false") Boolean includeCursor) {
+
+        List<ChatMessage> messages = chatMessageUseCase.getMessages(chatRoomId, cursor, pageSize, direction, includeCursor);
+        return ApiResponse.created(messages);
     }
 
     // 채팅방 특정 메세지 삭제
@@ -46,10 +59,12 @@ public class ChatMessageController {
     }
 
     // 채팅방 메세지 검색
+    // 키워드 포함된 메세지 모두 조회
     @GetMapping("/search")
-    public ApiResponse<List<ChatMessage>> searchMessages(@RequestParam String chatRoomId,
-                                                         @RequestParam String keyword) {
-
-        return ApiResponse.created(chatMessageUseCase.searchMessages(chatRoomId, keyword));
+    public ApiResponse<List<SearchResponse>> searchMessages(@RequestParam String chatRoomId, @RequestParam String keyword) {
+        List<ChatMessage> messages = chatMessageUseCase.searchMessages(chatRoomId, keyword);
+        return ApiResponse.created(messages.stream()
+                .map(SearchResponse::from)
+                .collect(Collectors.toList()));
     }
 }

--- a/src/main/java/com/zip/community/platform/adapter/in/web/dto/response/chat/SearchResponse.java
+++ b/src/main/java/com/zip/community/platform/adapter/in/web/dto/response/chat/SearchResponse.java
@@ -1,0 +1,34 @@
+package com.zip.community.platform.adapter.in.web.dto.response.chat;
+
+import com.zip.community.platform.domain.chat.ChatMessage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SearchResponse {
+
+    private String chatRoomId;
+    private String messageId;
+    private String content;
+    private Long senderId;
+    private String senderName;
+    private LocalDateTime sentAt;
+
+    public static SearchResponse from(ChatMessage message) {
+        return SearchResponse.builder()
+                .chatRoomId(message.getChatRoomId())
+                .messageId(message.getId())
+                .content(message.getContent())
+                .senderId(message.getSenderId())
+                .senderName(message.getSenderName())
+                .sentAt(message.getSentAt())
+                .build();
+    }
+}

--- a/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/repository/ChatMessageMongoRepository.java
+++ b/src/main/java/com/zip/community/platform/adapter/out/mongo/chat/repository/ChatMessageMongoRepository.java
@@ -11,5 +11,15 @@ public interface ChatMessageMongoRepository extends MongoRepository<ChatMessageD
 
     // 채팅방 내역 조회용 메소드: 채팅방 ID 기준으로 sentAt 내림차순 정렬 후 페이징 처리
     List<ChatMessageDocument> findByChatRoomIdOrderBySentAtDesc(String chatRoomId, Pageable pageable);
-    List<ChatMessageDocument> findByChatRoomIdAndContentContainingOrderBySentAtDesc(String chatRoomId, String keyword, Pageable pageable);
+    List<ChatMessageDocument> findByChatRoomIdAndContentContainingOrderBySentAtDesc(String chatRoomId, String keyword);
+
+    // 페이지네이션 (older)    // exclusive: 커서값을 포함하지 않음
+    List<ChatMessageDocument> findByChatRoomIdAndSentAtLessThanOrderBySentAtDesc(String chatRoomId, LocalDateTime sentAt, Pageable pageable);
+    // inclusive: 커서값을 포함함
+    List<ChatMessageDocument> findByChatRoomIdAndSentAtLessThanEqualOrderBySentAtDesc(String chatRoomId, LocalDateTime sentAt, Pageable pageable);
+
+    // 페이지네이션 (newer)    // exclusive: 커서값을 포함하지 않음
+    List<ChatMessageDocument> findByChatRoomIdAndSentAtGreaterThanOrderBySentAtAsc(String chatRoomId, LocalDateTime sentAt, Pageable pageable);
+    // inclusive: 커서값을 포함함
+    List<ChatMessageDocument> findByChatRoomIdAndSentAtGreaterThanEqualOrderBySentAtAsc(String chatRoomId, LocalDateTime sentAt, Pageable pageable);
 }

--- a/src/main/java/com/zip/community/platform/application/port/in/chat/ChatMessageUseCase.java
+++ b/src/main/java/com/zip/community/platform/application/port/in/chat/ChatMessageUseCase.java
@@ -3,13 +3,12 @@ package com.zip.community.platform.application.port.in.chat;
 import com.zip.community.platform.domain.chat.ChatMessage;
 import com.zip.community.platform.domain.report.ReportedChatMessage;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ChatMessageUseCase {
 
     ChatMessage sendMessage(ChatMessage message);
-    List<ChatMessage> getMessages(String chatRoomId, Integer page);
+    List<ChatMessage> getMessages(String chatRoomId, String cursor, Integer pageSize, String direction, Boolean includeCursor);
     ChatMessage deleteMessage(String messageId, Long memberId);
     ReportedChatMessage reportMessage(String messageId, Long reportMemberId, Long reportedMemberId, String reason);
     ChatMessage blockMessage(String messageId);

--- a/src/main/java/com/zip/community/platform/application/port/out/chat/ChatMessageMongoPort.java
+++ b/src/main/java/com/zip/community/platform/application/port/out/chat/ChatMessageMongoPort.java
@@ -5,15 +5,16 @@ import com.zip.community.platform.adapter.out.mongo.chat.ReportedChatMessageDocu
 import com.zip.community.platform.domain.chat.ChatMessage;
 import com.zip.community.platform.domain.report.ReportedChatMessage;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface ChatMessageMongoPort {
 
     ChatMessage save(ChatMessage message);
-    List<ChatMessage> getMessages(String chatRoomId, Integer page);
     Optional<ChatMessageDocument> findById(String messageId);
     ReportedChatMessage reportMessage(ReportedChatMessage reportedChatMessage);
+    List<ChatMessage> getMessages(String chatRoomId, String cursor, Integer pageSize, String direction, Boolean includeCursor);
     List<ChatMessage> searchMessages(String chatRoomId, String keyword);
     Optional<ReportedChatMessageDocument> getByMessageIdAndReportMemberId(String messageId, Long reportMemberId);
 }

--- a/src/main/java/com/zip/community/platform/application/service/chat/ChatMessageService.java
+++ b/src/main/java/com/zip/community/platform/application/service/chat/ChatMessageService.java
@@ -8,7 +8,6 @@ import com.zip.community.platform.application.port.out.chat.ChatRoomPort;
 import com.zip.community.platform.application.port.out.chat.MessageSendPort;
 import com.zip.community.platform.application.port.out.member.MemberPort;
 import com.zip.community.platform.domain.chat.ChatMessage;
-import com.zip.community.platform.domain.chat.ChatRoom;
 import com.zip.community.platform.domain.report.ReportedChatMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,8 +41,16 @@ public class ChatMessageService implements ChatMessageUseCase {
     }
 
     @Override
-    public List<ChatMessage> getMessages(String chatRoomId, Integer page) {
-        return chatMessageMongoPort.getMessages(chatRoomId, page);
+    public List<ChatMessage> getMessages(String chatRoomId, String cursor, Integer pageSize, String direction, Boolean includeCursor) {
+
+        // 채팅방 존재 확인
+        chatRoomPort.findByChatRoomId(chatRoomId)
+                .orElseThrow(() -> new CustomException(ChatErrorCode.NOT_FOUND_CHAT_ROOM));
+
+        if(!"older".equalsIgnoreCase(direction) && !"newer".equalsIgnoreCase(direction)) {
+            throw new CustomException(ChatErrorCode.INVALID_DIRECTION);
+        }
+        return chatMessageMongoPort.getMessages(chatRoomId, cursor, pageSize, direction, includeCursor);
     }
 
     @Override
@@ -105,7 +112,6 @@ public class ChatMessageService implements ChatMessageUseCase {
         return chatMessageMongoPort.save(message);
     }
 
-    // 해야함
     @Override
     public List<ChatMessage> searchMessages(String chatRoomId, String keyword) {
         return chatMessageMongoPort.searchMessages(chatRoomId, keyword);


### PR DESCRIPTION
## 📌 작업한 내용  
### 메세지 내역 조회 구현 - 커서 기반 조회
- 채팅방에 들어간 경우: 최신 메시지 20개 조회됨
- 사용자가 채팅방 내에서 위로 스크롤을 올리는 경우: 현재 조회된 메세지 중 가장 오래된 메세지의 `sendAt` 필드를 커서로 사용해 이전 메세지 조회
- 사용자가 채팅방 내에서 아래로 스크롤을 내리는 경우: 현재 조회된 메세지 중 가장 최신 메세지의 `sendAt` 필드를 커서로 사용해 이후 메세지 조회
### 메세지 검색 구현
- 채팅방 내 키워드(문자열)을 포함한 메세지들이 리스트로 조회됨
- 리스트 중 하나를 클릭하여 채팅방 내 해당 메세지 위치로 이동함

## 🔍 참고 사항

- **현재 검색기능은 Naver Works 의 채팅방 내 검색기능을 참고해서 구현하였습니다.**
- 채팅방 내에서 키워드로 검색하는 경우 해당 키워드가 포함된 메세지 내역들이 리스트로 보여지고 여기서 특정 메세지를 클릭하면 채팅방 내 해당 메세지 위치로 이동되는 것을 생각해서 구현하였습니다.

## 🖼️ 스크린샷  
### 메세지 내역 조회
#### case1) 사용자가 채팅방에 처음 들어간 경우
- 해당 채팅방내 가장 최신 20개의 데이터가 조회되어 반환됨
- 가장 최신 20개의 데이터를 조회하므로 `cursor` 파라미터는 지정하지 않음
<img width="850" alt="스크린샷 2025-03-15 오후 1 54 00" src="https://github.com/user-attachments/assets/d3f78bda-5b3c-4216-acb2-e3f7a5f2b338" />

#### case2) 사용자가 채팅방 내에서 위로 스크롤을 올리는 경우
- 이전 메세지를 조회하기 위해 스크롤을 위로 올림
- 현재 조회된 메세지에서 가장 오래된 메세지의 `sentAt` 필드를 커서로 사용
- 이전 메세지를 조회하므로 `direction=older`, 현재 커서로 사용하는 채팅메세지의 내용이 포함되지 않고 이전 메세지만 조회되어야 하므로 `includeCursor=false`
<img width="835" alt="스크린샷 2025-03-15 오후 2 04 07" src="https://github.com/user-attachments/assets/66453173-f4da-49d1-a440-8860e9016594" />

#### case3) 사용자가 채팅방 내에서 아래로 스크롤을 내리는 경우
- 이후 메세지를 조회하기 위해 스크롤을 아래로 내림
- 현재 조회된 메세지에서 가장 최신 메세지의 `sentAt` 필드를 커서로 사용
- 이전 메세지를 조회하므로 `direction=newer`, 현재 커서로 사용하는 채팅메세지의 내용이 포함되지 않고 이전 메세지만 조회되어야 하므로 `includeCursor=false`
<img width="839" alt="스크린샷 2025-03-15 오후 2 06 05" src="https://github.com/user-attachments/assets/8f047888-621a-42c4-ab64-7b3434cd2180" />

#### case4) 채팅방 내 메세지 검색후 해당 메세지 확인하는 경우
- 사용자가 채팅방 내에서 메세지를 검색하면 해당 메세지가 리스트로 조회됨
- 여기서 하나를 클릭하면 채팅방 내 해당 메세지가 존재하는 위치로 이동시켜야함 (ux 고려)
- 이때도 선택한 메세지의 커서 값을 사용해서 해당 페이지크기만큼 조회하는데 커서로 사용하는 채팅메세지의 내용이 포함되어 조회되어야함
- 사용자가 검색을 통해 채팅방내 메세지가 위치한 곳으로 조회가 되었고, 이후 스크롤을 올리거나 내리면서(**case2, case3**) 채팅방내 다른 메세지도 계속 조회가 가능하도록 구현하였음
<img width="839" alt="스크린샷 2025-03-15 오후 2 11 36" src="https://github.com/user-attachments/assets/c038f470-ab61-41cb-9626-d3cb59299489" />

### 메세지 검색
- 특정 키워드(문자열)로 메세지 검색시 채팅방 내에 해당 키워드를 포함한 메세지가 리스트로 조회됨
- 검색된 메세지 리스트중 하나를 클릭해서 채팅방 해당 메세지 위치로 이동하는 것은 **case4** 참고
<img width="855" alt="스크린샷 2025-03-15 오후 2 13 38" src="https://github.com/user-attachments/assets/f970a1c0-7d6b-45c2-b3c2-48267f2e5a92" />

## 🔗 관련 이슈  
- [feat: 채팅 기능 구현 #5](https://github.com/ZiP-Official/Community-server/issues/5#issue-2904597817)

## ✅ 체크리스트  
- [x] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
